### PR TITLE
Add Go cache implementation with write-heavy and read-heavy strategies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,23 @@
+name: Go
+on: [push]
+jobs:
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["1.23.x"]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: test
+        run: |
+          make vet
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test
+test:
+	go test -cover ./...
+
+.PHONY: bench
+bench:
+	go test -bench=. -benchmem
+
+.PHONY: vet
+vet:
+	go vet ./...

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,142 @@
+package cache
+
+import "sync"
+
+type WriteHeavyCache[K comparable, V any] struct {
+	sync.Mutex // For Write Heavy, use Mutex for all operations
+	items      map[K]V
+}
+
+type ReadHeavyCache[K comparable, V any] struct {
+	sync.RWMutex // For Read Heavy, allow concurrent read access
+	items        map[K]V
+}
+
+// Write Heavy methods
+func (c *WriteHeavyCache[K, V]) Set(key K, value V) {
+	c.Lock() // Lock for writing
+	c.items[key] = value
+	c.Unlock()
+}
+
+func (c *WriteHeavyCache[K, V]) Get(key K) (V, bool) {
+	c.Lock() // Lock for reading as well, single-thread access
+	v, found := c.items[key]
+	c.Unlock()
+	return v, found
+}
+
+// Read Heavy methods
+func (c *ReadHeavyCache[K, V]) Set(key K, value V) {
+	c.Lock() // Lock for writing
+	c.items[key] = value
+	c.Unlock()
+}
+
+func (c *ReadHeavyCache[K, V]) Get(key K) (V, bool) {
+	c.RLock() // RLock for reading, allows multiple concurrent reads
+	v, found := c.items[key]
+	c.RUnlock()
+	return v, found
+}
+
+// Constructor for Write Heavy cache
+func NewWriteHeavyCache[K comparable, V any]() *WriteHeavyCache[K, V] {
+	return &WriteHeavyCache[K, V]{
+		items: make(map[K]V),
+	}
+}
+
+// Constructor for Read Heavy cache
+func NewReadHeavyCache[K comparable, V any]() *ReadHeavyCache[K, V] {
+	return &ReadHeavyCache[K, V]{
+		items: make(map[K]V),
+	}
+}
+
+// cacheInteger with manual type constraints for integer-like types.
+type WriteHeavyCacheInteger[K comparable, V interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}] struct {
+	sync.Mutex // Use Mutex for write-heavy scenarios
+	items      map[K]V
+}
+
+type ReadHeavyCacheInteger[K comparable, V interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}] struct {
+	sync.RWMutex // Use RWMutex for read-heavy scenarios
+	items        map[K]V
+}
+
+// NewWriteHeavyCacheInteger constructor for creating a new write-heavy cache.
+func NewWriteHeavyCacheInteger[K comparable, V interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}]() *WriteHeavyCacheInteger[K, V] {
+	return &WriteHeavyCacheInteger[K, V]{
+		items: make(map[K]V),
+	}
+}
+
+// NewReadHeavyCacheInteger constructor for creating a new read-heavy cache.
+func NewReadHeavyCacheInteger[K comparable, V interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}]() *ReadHeavyCacheInteger[K, V] {
+	return &ReadHeavyCacheInteger[K, V]{
+		items: make(map[K]V),
+	}
+}
+
+// Write-heavy Set method using Mutex
+func (c *WriteHeavyCacheInteger[K, V]) Set(key K, value V) {
+	c.Lock() // Lock for writing
+	c.items[key] = value
+	c.Unlock() // Unlock after write is complete
+}
+
+// Write-heavy Get method using Mutex
+func (c *WriteHeavyCacheInteger[K, V]) Get(key K) (V, bool) {
+	c.Lock() // Lock for reading (Mutex is used for both read and write)
+	v, found := c.items[key]
+	c.Unlock() // Unlock after read is complete
+	return v, found
+}
+
+// Write-heavy Incr method using Mutex
+func (c *WriteHeavyCacheInteger[K, V]) Incr(key K, value V) {
+	c.Lock() // Lock for incrementing
+	v, found := c.items[key]
+	if found {
+		c.items[key] = v + value
+	} else {
+		c.items[key] = value
+	}
+	c.Unlock() // Unlock after modification
+}
+
+// Read-heavy Set method using RWMutex
+func (c *ReadHeavyCacheInteger[K, V]) Set(key K, value V) {
+	c.Lock() // Lock for writing
+	c.items[key] = value
+	c.Unlock() // Unlock after write is complete
+}
+
+// Read-heavy Get method using RWMutex
+func (c *ReadHeavyCacheInteger[K, V]) Get(key K) (V, bool) {
+	c.RLock() // RLock for reading, allows multiple concurrent reads
+	v, found := c.items[key]
+	c.RUnlock() // Unlock after read is complete
+	return v, found
+}
+
+// Read-heavy Incr method using RWMutex
+func (c *ReadHeavyCacheInteger[K, V]) Incr(key K, value V) {
+	c.Lock() // Lock for incrementing (write operation)
+	v, found := c.items[key]
+	if found {
+		c.items[key] = v + value
+	} else {
+		c.items[key] = value
+	}
+	c.Unlock() // Unlock after modification
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,373 @@
+package cache_test
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/catatsuy/cache"
+)
+
+func TestWriteHeavyCache_SetAndGet(t *testing.T) {
+	cache := cache.NewWriteHeavyCache[string, int]()
+	cache.Set("key1", 100)
+
+	if value, found := cache.Get("key1"); !found {
+		t.Errorf("Expected key1 to be found")
+	} else if value != 100 {
+		t.Errorf("Expected value 100 for key1, but got %d", value)
+	}
+}
+
+func TestReadHeavyCache_SetAndGet(t *testing.T) {
+	cache := cache.NewReadHeavyCache[string, int]()
+	cache.Set("key1", 200)
+
+	if value, found := cache.Get("key1"); !found {
+		t.Errorf("Expected key1 to be found")
+	} else if value != 200 {
+		t.Errorf("Expected value 200 for key1, but got %d", value)
+	}
+}
+
+func TestWriteHeavyCacheInteger_SetAndGet(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	cache.Set(1, 300)
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 300 {
+		t.Errorf("Expected value 300 for key 1, but got %d", value)
+	}
+}
+
+func TestReadHeavyCacheInteger_SetAndGet(t *testing.T) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	cache.Set(1, 400)
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 400 {
+		t.Errorf("Expected value 400 for key 1, but got %d", value)
+	}
+}
+
+func TestWriteHeavyCacheInteger_Incr(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	cache.Incr(1, 10) // Key doesn't exist, should set to 10
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 10 {
+		t.Errorf("Expected value 10 for key 1, but got %d", value)
+	}
+
+	cache.Incr(1, 5) // Increment by 5, should be 15
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 15 {
+		t.Errorf("Expected value 15 for key 1, but got %d", value)
+	}
+}
+
+func TestReadHeavyCacheInteger_Incr(t *testing.T) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	cache.Incr(1, 20) // Key doesn't exist, should set to 20
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 20 {
+		t.Errorf("Expected value 20 for key 1, but got %d", value)
+	}
+
+	cache.Incr(1, 10) // Increment by 10, should be 30
+
+	if value, found := cache.Get(1); !found {
+		t.Errorf("Expected key 1 to be found")
+	} else if value != 30 {
+		t.Errorf("Expected value 30 for key 1, but got %d", value)
+	}
+}
+
+func TestWriteHeavyCache_ParallelWrite(t *testing.T) {
+	cache := cache.NewWriteHeavyCache[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	// Write to the cache concurrently from GOMAXPROCS goroutines
+	for p := range numProcs {
+		wg.Add(1)
+		go func(procID int) {
+			defer wg.Done()
+			for i := range 1000 {
+				cache.Set(procID*1000+i, i) // Unique keys per goroutine to avoid race conditions
+			}
+		}(p)
+	}
+
+	wg.Wait()
+
+	// Verify if all values are set correctly
+	for p := 0; p < numProcs; p++ {
+		for i := range 1000 {
+			if value, found := cache.Get(p*1000 + i); !found || value != i {
+				t.Errorf("Expected value %d for key %d, but got %d (found: %v)", i, p*1000+i, value, found)
+			}
+		}
+	}
+}
+
+func TestReadHeavyCache_ParallelWrite(t *testing.T) {
+	cache := cache.NewReadHeavyCache[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	// Write to the cache concurrently from GOMAXPROCS goroutines
+	for p := range numProcs {
+		wg.Add(1)
+		go func(procID int) {
+			defer wg.Done()
+			for i := range 1000 {
+				cache.Set(procID*1000+i, i) // Unique keys per goroutine to avoid race conditions
+			}
+		}(p)
+	}
+
+	wg.Wait()
+
+	// Verify if all values are set correctly
+	for p := 0; p < numProcs; p++ {
+		for i := range 1000 {
+			if value, found := cache.Get(p*1000 + i); !found || value != i {
+				t.Errorf("Expected value %d for key %d, but got %d (found: %v)", i, p*1000+i, value, found)
+			}
+		}
+	}
+}
+
+// Benchmark for WriteHeavyCache's Set method
+func BenchmarkWriteHeavyCache_Set(b *testing.B) {
+	cache := cache.NewWriteHeavyCache[int, int]()
+	b.ResetTimer() // Reset the timer to ignore the setup time
+
+	for i := range b.N {
+		cache.Set(i, i)
+	}
+}
+
+// Benchmark for WriteHeavyCache's Get method
+func BenchmarkWriteHeavyCache_Get(b *testing.B) {
+	cache := cache.NewWriteHeavyCache[int, int]()
+	for i := range 1000 {
+		cache.Set(i, i)
+	}
+	b.ResetTimer()
+
+	for i := range b.N {
+		cache.Get(i % 1000) // Access the existing keys
+	}
+}
+
+// Benchmark for ReadHeavyCache's Set method
+func BenchmarkReadHeavyCache_Set(b *testing.B) {
+	cache := cache.NewReadHeavyCache[int, int]()
+	b.ResetTimer()
+
+	for i := range b.N {
+		cache.Set(i, i)
+	}
+}
+
+// Benchmark for ReadHeavyCache's Get method
+func BenchmarkReadHeavyCache_Get(b *testing.B) {
+	cache := cache.NewReadHeavyCache[int, int]()
+	for i := range 1000 {
+		cache.Set(i, i)
+	}
+	b.ResetTimer()
+
+	for i := range b.N {
+		cache.Get(i % 1000)
+	}
+}
+
+// Benchmark for WriteHeavyCacheInteger's Incr method
+func BenchmarkWriteHeavyCacheInteger_Incr(b *testing.B) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	for i := range 1000 {
+		cache.Set(i, i)
+	}
+	b.ResetTimer()
+
+	for i := range b.N {
+		cache.Incr(i%1000, 1)
+	}
+}
+
+// Benchmark for ReadHeavyCacheInteger's Incr method
+func BenchmarkReadHeavyCacheInteger_Incr(b *testing.B) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	for i := range 1000 {
+		cache.Set(i, i)
+	}
+	b.ResetTimer()
+
+	for i := range b.N {
+		cache.Incr(i%1000, 1)
+	}
+}
+
+func BenchmarkWriteHeavyCache_ParallelWrite(b *testing.B) {
+	cache := cache.NewWriteHeavyCache[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel writes using GOMAXPROCS goroutines
+		for p := range numProcs {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					cache.Set(procID*1000+j, j)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkReadHeavyCache_ParallelWrite(b *testing.B) {
+	cache := cache.NewReadHeavyCache[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel writes using GOMAXPROCS goroutines
+		for p := range numProcs {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := range 1000 {
+					cache.Set(procID*1000+j, j)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}
+
+// Benchmark for parallel writes in WriteHeavyCacheInteger
+func BenchmarkWriteHeavyCacheInteger_ParallelWrite(b *testing.B) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel writes using GOMAXPROCS goroutines
+		for p := 0; p < numProcs; p++ {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					cache.Set(procID*1000+j, j)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}
+
+// Benchmark for parallel writes in ReadHeavyCacheInteger
+func BenchmarkReadHeavyCacheInteger_ParallelWrite(b *testing.B) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel writes using GOMAXPROCS goroutines
+		for p := 0; p < numProcs; p++ {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					cache.Set(procID*1000+j, j)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}
+
+// Benchmark for parallel increments in WriteHeavyCacheInteger
+func BenchmarkWriteHeavyCacheInteger_ParallelIncr(b *testing.B) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	// Initialize cache with some values
+	for i := range 1000 * numProcs {
+		cache.Set(i, i)
+	}
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel increments using GOMAXPROCS goroutines
+		for p := 0; p < numProcs; p++ {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					cache.Incr(procID*1000+j, 1)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}
+
+// Benchmark for parallel increments in ReadHeavyCacheInteger
+func BenchmarkReadHeavyCacheInteger_ParallelIncr(b *testing.B) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	var wg sync.WaitGroup
+
+	numProcs := runtime.GOMAXPROCS(0) // Get the number of available processors
+
+	// Initialize cache with some values
+	for i := range 1000 * numProcs {
+		cache.Set(i, i)
+	}
+
+	b.ResetTimer() // Reset the timer to ignore setup time
+
+	for range b.N {
+		// Parallel increments using GOMAXPROCS goroutines
+		for p := 0; p < numProcs; p++ {
+			wg.Add(1)
+			go func(procID int) {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					cache.Incr(procID*1000+j, 1)
+				}
+			}(p)
+		}
+		wg.Wait()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/catatsuy/cache
+
+go 1.23


### PR DESCRIPTION
This pull request introduces a new caching system with distinct implementations for write-heavy and read-heavy scenarios, along with corresponding tests and benchmarks. Additionally, it sets up a GitHub Actions workflow for continuous integration.

### New Caching System:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R1-R142): Added `WriteHeavyCache` and `ReadHeavyCache` types with methods for setting and getting values, including specialized integer caches with increment methods.
* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R1-R373): Added comprehensive tests for the new cache types, including parallel write tests and benchmarks for performance evaluation.

### Continuous Integration Setup:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR1-R23): Added a GitHub Actions workflow to run tests and vet the code on push events using Go 1.23.x.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R11): Added `test`, `bench`, and `vet` targets to facilitate testing, benchmarking, and code vetting.

### Module Definition:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R1-R3): Defined the module for the project and specified Go 1.23 as the version.