### PR TITLE
Add documentation section with link to full API on pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This library provides two types of caches optimized for different usage patterns
 - Supports **generic types** for flexible key-value storage.
 - Specialized caches for **integer-like types** to support operations like increments.
 
+## Documentation
+
+For full API documentation, visit [pkg.go.dev](https://pkg.go.dev/github.com/catatsuy/cache).
+
 ## Usage
 
 ### WriteHeavyCache


### PR DESCRIPTION
This pull request updates the documentation for the caching library in the `README.md` file to include a link to the full API documentation.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R15): Added a new "Documentation" section with a link to the full API documentation at `pkg.go.dev`.