### PR TITLE
Add Clear() method to all cache types and corresponding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,23 +133,27 @@ func main() {
 
 - **`Set(key K, value V)`**: Stores the given key-value pair in the cache.
 - **`Get(key K) (V, bool)`**: Retrieves the value associated with the key, returning a boolean indicating whether the key exists.
+- **`Clear()`**: Removes all key-value pairs from the cache.
 
 ### ReadHeavyCache
 
 - **`Set(key K, value V)`**: Stores the given key-value pair in the cache.
 - **`Get(key K) (V, bool)`**: Retrieves the value associated with the key, allowing concurrent reads.
+- **`Clear()`**: Removes all key-value pairs from the cache.
 
 ### WriteHeavyCacheInteger
 
 - **`Set(key K, value V)`**: Stores the given key-value pair in the cache.
 - **`Get(key K) (V, bool)`**: Retrieves the value associated with the key.
 - **`Incr(key K, value V)`**: Increments the value by the given amount. If the key does not exist, it sets the value.
+- **`Clear()`**: Removes all key-value pairs from the cache.
 
 ### ReadHeavyCacheInteger
 
 - **`Set(key K, value V)`**: Stores the given key-value pair in the cache.
 - **`Get(key K) (V, bool)`**: Retrieves the value associated with the key.
 - **`Incr(key K, value V)`**: Increments the value by the given amount. If the key does not exist, it sets the value.
+- **`Clear()`**: Removes all key-value pairs from the cache.
 
 ## Acknowledgements
 

--- a/cache.go
+++ b/cache.go
@@ -27,6 +27,13 @@ func (c *WriteHeavyCache[K, V]) Get(key K) (V, bool) {
 	return v, found
 }
 
+// Clear removes all items from WriteHeavyCache
+func (c *WriteHeavyCache[K, V]) Clear() {
+	c.Lock()
+	c.items = make(map[K]V)
+	c.Unlock()
+}
+
 // Set sets a value in ReadHeavyCache, locking for the write operation
 func (c *ReadHeavyCache[K, V]) Set(key K, value V) {
 	c.Lock()
@@ -40,6 +47,13 @@ func (c *ReadHeavyCache[K, V]) Get(key K) (V, bool) {
 	v, found := c.items[key]
 	c.RUnlock()
 	return v, found
+}
+
+// Clear removes all items from ReadHeavyCache
+func (c *ReadHeavyCache[K, V]) Clear() {
+	c.Lock()
+	c.items = make(map[K]V)
+	c.Unlock()
 }
 
 // NewWriteHeavyCache creates a new instance of WriteHeavyCache
@@ -117,6 +131,12 @@ func (c *WriteHeavyCacheInteger[K, V]) Incr(key K, value V) {
 	c.Unlock()
 }
 
+func (c *WriteHeavyCacheInteger[K, V]) Clear() {
+	c.Lock()
+	c.items = make(map[K]V)
+	c.Unlock()
+}
+
 // Set sets a value in ReadHeavyCacheInteger, locking for the write operation
 func (c *ReadHeavyCacheInteger[K, V]) Set(key K, value V) {
 	c.Lock()
@@ -141,5 +161,11 @@ func (c *ReadHeavyCacheInteger[K, V]) Incr(key K, value V) {
 	} else {
 		c.items[key] = value
 	}
+	c.Unlock()
+}
+
+func (c *ReadHeavyCacheInteger[K, V]) Clear() {
+	c.Lock()
+	c.items = make(map[K]V)
 	c.Unlock()
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -30,6 +30,36 @@ func TestReadHeavyCache_SetAndGet(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCache_Clear(t *testing.T) {
+	cache := cache.NewWriteHeavyCache[string, int]()
+	cache.Set("key1", 100)
+	cache.Set("key2", 200)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
+func TestReadHeavyCache_Clear(t *testing.T) {
+	cache := cache.NewReadHeavyCache[string, int]()
+	cache.Set("key1", 100)
+	cache.Set("key2", 200)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
 func TestWriteHeavyCacheInteger_SetAndGet(t *testing.T) {
 	cache := cache.NewWriteHeavyCacheInteger[int, int]()
 	cache.Set(1, 300)
@@ -87,6 +117,36 @@ func TestReadHeavyCacheInteger_Incr(t *testing.T) {
 		t.Errorf("Expected key 1 to be found")
 	} else if value != 30 {
 		t.Errorf("Expected value 30 for key 1, but got %d", value)
+	}
+}
+
+func TestWriteHeavyCacheInteger_Clear(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheInteger[string, int]()
+	cache.Set("key1", 100)
+	cache.Set("key2", 200)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
+func TestReadHeavyCacheInteger_Clear(t *testing.T) {
+	cache := cache.NewReadHeavyCacheInteger[string, int]()
+	cache.Set("key1", 100)
+	cache.Set("key2", 200)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a `Clear` method to various cache types and includes corresponding tests. The most important changes include adding the `Clear` method to the `WriteHeavyCache`, `ReadHeavyCache`, `WriteHeavyCacheInteger`, and `ReadHeavyCacheInteger` types, as well as updating the `README.md` to reflect these changes and adding tests for the new method.

### Cache Method Additions:
* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R30-R36): Added `Clear` method to `WriteHeavyCache`, `ReadHeavyCache`, `WriteHeavyCacheInteger`, and `ReadHeavyCacheInteger` types. (`[[1]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R30-R36)`, `[[2]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R52-R58)`, `[[3]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R134-R139)`, `[[4]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R166-R171)`)

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R156): Updated to include the `Clear` method for all cache types. (`[README.mdR136-R156](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R156)`)

### Test Additions:
* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R33-R62): Added tests for the `Clear` method for `WriteHeavyCache`, `ReadHeavyCache`, `WriteHeavyCacheInteger`, and `ReadHeavyCacheInteger` types. (`[[1]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R33-R62)`, `[[2]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R123-R152)`)