### PR TITLE
Add WriteHeavyCacheExpired and ReadHeavyCacheExpired with examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,83 @@ func main() {
 }
 ```
 
+### WriteHeavyCacheExpired and ReadHeavyCacheExpired
+
+The `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` caches provide expiration functionality for stored items. You can specify an expiration duration for each item, after which it will no longer be accessible.
+
+- **WriteHeavyCacheExpired**: Optimized for write-heavy scenarios, using `sync.Mutex` for all operations.
+- **ReadHeavyCacheExpired**: Optimized for read-heavy scenarios, using `sync.RWMutex` to allow multiple readers concurrently while still locking for writes.
+
+#### WriteHeavyCacheExpired Example
+
+The `WriteHeavyCacheExpired` cache is designed for situations where write operations are more frequent.
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/catatsuy/cache"
+)
+
+func main() {
+	c := cache.NewWriteHeavyCacheExpired[int, string]()
+
+	// Set an item with a 1-second expiration
+	c.Set(1, "apple", 1*time.Second)
+
+	// Retrieve the item immediately
+	if value, found := c.Get(1); found {
+		fmt.Println("Found:", value) // Output: Found: apple
+	} else {
+		fmt.Println("Not found")
+	}
+
+	// Wait for the item to expire
+	time.Sleep(2 * time.Second)
+	if _, found := c.Get(1); !found {
+		fmt.Println("Item has expired") // Output: Item has expired
+	}
+}
+```
+
+#### ReadHeavyCacheExpired Example
+
+The `ReadHeavyCacheExpired` cache is designed for scenarios where read operations are more frequent than writes.
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/catatsuy/cache"
+)
+
+func main() {
+	c := cache.NewReadHeavyCacheExpired[int, string]()
+
+	// Set an item with a 1-second expiration
+	c.Set(1, "orange", 1*time.Second)
+
+	// Retrieve the item immediately
+	if value, found := c.Get(1); found {
+		fmt.Println("Found:", value) // Output: Found: orange
+	} else {
+		fmt.Println("Not found")
+	}
+
+	// Wait for the item to expire
+	time.Sleep(2 * time.Second)
+	if _, found := c.Get(1); !found {
+		fmt.Println("Item has expired") // Output: Item has expired
+	}
+}
+```
+
 ### Integer-Specific Caches
 
 For scenarios where you need to increment values stored in the cache, the library provides `WriteHeavyCacheInteger` and `ReadHeavyCacheInteger` for integer-like types.
@@ -207,6 +284,16 @@ Using `Lock` and `Unlock` directly allows you to control when the lock is held a
 - **`Set(key K, value V)`**: Stores the given key-value pair in the cache.
 - **`Get(key K) (V, bool)`**: Retrieves the value associated with the key, allowing concurrent reads.
 - **`Clear()`**: Removes all key-value pairs from the cache.
+
+### WriteHeavyCacheExpired
+
+- **`Set(key K, value V, duration time.Duration)`**: Stores the given key-value pair in the cache with an expiration duration.
+- **`Get(key K) (V, bool)`**: Retrieves the value associated with the key if it exists and is not expired. Returns a boolean indicating whether the key is still valid.
+
+### ReadHeavyCacheExpired
+
+- **`Set(key K, value V, duration time.Duration)`**: Stores the given key-value pair in the cache with an expiration duration.
+- **`Get(key K) (V, bool)`**: Retrieves the value associated with the key if it exists and is not expired. Returns a boolean indicating whether the key is still valid.
 
 ### WriteHeavyCacheInteger
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -210,6 +210,42 @@ func TestReadHeavyCache_ParallelWrite(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCacheExpired_SetAndGet(t *testing.T) {
+	c := cache.NewWriteHeavyCacheExpired[int, string]()
+
+	// Set an item with a 1-second expiration
+	c.Set(1, "test", 1*time.Second)
+
+	// Retrieve the item immediately
+	if value, found := c.Get(1); !found || value != "test" {
+		t.Errorf("Expected 'test', got %v", value)
+	}
+
+	// Wait for 2 seconds and check if it expires
+	time.Sleep(2 * time.Second)
+	if _, found := c.Get(1); found {
+		t.Error("Expected item to be expired, but it was found")
+	}
+}
+
+func TestReadHeavyCacheExpired_SetAndGet(t *testing.T) {
+	c := cache.NewReadHeavyCacheExpired[int, string]()
+
+	// Set an item with a 1-second expiration
+	c.Set(1, "test", 1*time.Second)
+
+	// Retrieve the item immediately
+	if value, found := c.Get(1); !found || value != "test" {
+		t.Errorf("Expected 'test', got %v", value)
+	}
+
+	// Wait for 2 seconds and check if it expires
+	time.Sleep(2 * time.Second)
+	if _, found := c.Get(1); found {
+		t.Error("Expected item to be expired, but it was found")
+	}
+}
+
 // Benchmark for WriteHeavyCache's Set method
 func BenchmarkWriteHeavyCache_Set(b *testing.B) {
 	cache := cache.NewWriteHeavyCache[int, int]()


### PR DESCRIPTION
This pull request introduces new cache types with expiration functionality and updates the documentation and tests accordingly. The most important changes include the addition of `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` types, along with their respective methods and examples.

### New Cache Types with Expiration:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R76-R148): Added `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` types, which use `sync.Mutex` and `sync.RWMutex` respectively, along with their `Set` and `Get` methods to handle expiration of items.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R148): Added sections and examples for `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired`, explaining their usage and providing code snippets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R148) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R288-R297)

### Tests:

* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R213-R248): Added tests for `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` to verify the `Set` and `Get` methods, including expiration handling.

### Imports:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042L3-R6): Updated imports to include `time` package for handling expiration.