### PR TITLE
refactor SingleflightGroup to use string keys only

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,21 +282,22 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/catatsuy/cache"
 )
 
 func main() {
-	sf := cache.NewSingleflightGroup[int, string]()
+	sf := cache.NewSingleflightGroup[string]()
 
 	// Define a function to load data only if it's not already cached
-	loadData := func(key int) (string, error) {
+	loadData := func(key string) (string, error) {
 		// Simulate data fetching or updating
-		return fmt.Sprintf("Data for key %d", key), nil
+		return fmt.Sprintf("Data for key %s", key), nil
 	}
 
 	// Use SingleflightGroup to ensure only one call for the same key at a time
-	value, err := sf.Do(1, func() (string, error) {
-		return loadData(1)
+	value, err := sf.Do("key", func() (string, error) {
+		return loadData("key")
 	})
 
 	if err != nil {
@@ -317,7 +318,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
 	"github.com/catatsuy/cache"
@@ -326,7 +326,7 @@ import (
 // Global cache and singleflight group
 var (
 	c  = cache.NewWriteHeavyCache[int, int]()
-	sf = cache.NewSingleflightGroup[string, int]()
+	sf = cache.NewSingleflightGroup[int]()
 )
 
 // Get retrieves a value from the cache or loads it with HeavyGet if not cached.
@@ -426,8 +426,8 @@ This example shows how multiple simultaneous requests for the same key result in
 
 ### SingleflightGroup
 
-- **`NewSingleflightGroup[K comparable, V any]()`**: Creates a new instance of `SingleflightGroup`.
-- **`Do(key K, fn func() (V, error)) (V, error)`**: Executes the provided function `fn` for the given key only if it is not already in progress for that key. If a duplicate request is made with the same key while the function is still running, the duplicate request waits and receives the same result when the function completes.
+- **`NewSingleflightGroup[V any]()`**: Creates a new instance of `SingleflightGroup`.
+- **`Do(key string, fn func() (V, error)) (V, error)`**: Executes the provided function `fn` for the given key only if it is not already in progress for that key. If a duplicate request is made with the same key while the function is still running, the duplicate request waits and receives the same result when the function completes.
 
 ## Acknowledgements
 

--- a/example_test.go
+++ b/example_test.go
@@ -169,7 +169,7 @@ func ExampleLockManager() {
 }
 
 func ExampleSingleflightGroup() {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 
 	v, err := sf.Do("example_key", func() (string, error) {
 		return "result", nil

--- a/singleflight.go
+++ b/singleflight.go
@@ -18,9 +18,9 @@ import (
 //   - Immediate synchronous cleanup: In this implementation, the completed result is
 //     removed from the map asynchronously. In the official implementation, cleanup
 //     is handled synchronously within the doCall function to ensure immediate memory release.
-type SingleflightGroup[K comparable, V any] struct {
+type SingleflightGroup[V any] struct {
 	mu sync.Mutex
-	m  map[K]*call[V]
+	m  map[string]*call[V]
 }
 
 // call represents a single execution result for a specific key, holding the
@@ -34,9 +34,9 @@ type call[V any] struct {
 
 // NewSingleflightGroup creates a new instance of SingleflightGroup, initialized
 // with an empty map to store calls by key.
-func NewSingleflightGroup[K comparable, V any]() *SingleflightGroup[K, V] {
-	return &SingleflightGroup[K, V]{
-		m: make(map[K]*call[V]),
+func NewSingleflightGroup[V any]() *SingleflightGroup[V] {
+	return &SingleflightGroup[V]{
+		m: make(map[string]*call[V]),
 	}
 }
 
@@ -49,7 +49,7 @@ func NewSingleflightGroup[K comparable, V any]() *SingleflightGroup[K, V] {
 //
 // - Panic and Goexit handling
 // - Shared result flag to indicate if the result was reused for multiple callers
-func (sf *SingleflightGroup[K, V]) Do(key K, fn func() (V, error)) (V, error) {
+func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (V, error) {
 	// Lock to check if a call is already in progress for the given key
 	sf.mu.Lock()
 	var (

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDo(t *testing.T) {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 	v, err := sf.Do("key", func() (string, error) {
 		return "bar", nil
 	})
@@ -24,7 +24,7 @@ func TestDo(t *testing.T) {
 }
 
 func TestDoErr(t *testing.T) {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 	someErr := errors.New("Some error")
 	v, err := sf.Do("key", func() (string, error) {
 		return "", someErr
@@ -38,7 +38,7 @@ func TestDoErr(t *testing.T) {
 }
 
 func TestDoDupSuppress(t *testing.T) {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 	var wg1, wg2 sync.WaitGroup
 	c := make(chan string, 1)
 	var calls int32
@@ -85,7 +85,7 @@ func TestDoDupSuppress(t *testing.T) {
 }
 
 func TestDoTimeout(t *testing.T) {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 	start := time.Now()
 	v, err := sf.Do("key", func() (string, error) {
 		time.Sleep(100 * time.Millisecond)
@@ -103,7 +103,7 @@ func TestDoTimeout(t *testing.T) {
 }
 
 func TestDoMultipleErrors(t *testing.T) {
-	sf := cache.NewSingleflightGroup[string, string]()
+	sf := cache.NewSingleflightGroup[string]()
 	var calls int32
 	someErr := errors.New("Some error")
 


### PR DESCRIPTION
This pull request focuses on simplifying the `SingleflightGroup` implementation by removing the generic key type and standardizing it to use strings. This change affects multiple files, including the main package, examples, and tests.

Key changes:

### Simplification of `SingleflightGroup`:

* [`singleflight.go`](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L21-R23): Modified `SingleflightGroup` to use `string` as the key type instead of a generic comparable type. Updated the `Do` method and `NewSingleflightGroup` function accordingly. [[1]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L21-R23) [[2]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L37-R39) [[3]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L52-R52)

### Updates to examples and tests:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R285-R300): Updated example usage of `SingleflightGroup` to reflect the new key type. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R285-R300) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L429-R430)
* [`example_test.go`](diffhunk://#diff-c2ade2f386c41794d5ebc57ee49b57a5fca8082e03255e5bff13977cbc061287L172-R172): Adjusted the example to use the updated `SingleflightGroup` with string keys.
* [`singleflight_test.go`](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL14-R14): Updated all test cases to use the new `SingleflightGroup` with string keys. [[1]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL14-R14) [[2]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL27-R27) [[3]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL41-R41) [[4]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL88-R88) [[5]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL106-R106)