### PR TITLE
Fix comment formatting in NewSingleflightGroup function documentation

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -45,10 +45,9 @@ func NewSingleflightGroup[V any]() *SingleflightGroup[V] {
 // and return the same result. Once complete, the result is stored and used for
 // subsequent calls until it's removed from the map.
 //
-//	Unlike the official singleflight, this function does not provide:
-//
-// - Panic and Goexit handling
-// - Shared result flag to indicate if the result was reused for multiple callers
+// Unlike the official singleflight, this function does not provide:
+//   - Panic and Goexit handling
+//   - Shared result flag to indicate if the result was reused for multiple callers
 func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (V, error) {
 	// Lock to check if a call is already in progress for the given key
 	sf.mu.Lock()


### PR DESCRIPTION
This pull request includes a minor documentation update to the `singleflight.go` file. The update removes an unnecessary empty comment line in the `NewSingleflightGroup` function.

Documentation update:

* [`singleflight.go`](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L49): Removed an empty comment line in the `NewSingleflightGroup` function.