### PR TITLE
Add Delete method to cache types and corresponding unit tests.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -34,6 +34,13 @@ func (c *WriteHeavyCache[K, V]) Get(key K) (V, bool) {
 	return v, found
 }
 
+// Delete removes a key from WriteHeavyCache.
+func (c *WriteHeavyCache[K, V]) Delete(key K) {
+	c.Lock()
+	delete(c.items, key)
+	c.Unlock()
+}
+
 // Clear removes all items from WriteHeavyCache
 func (c *WriteHeavyCache[K, V]) Clear() {
 	c.Lock()
@@ -54,6 +61,13 @@ func (c *ReadHeavyCache[K, V]) Get(key K) (V, bool) {
 	v, found := c.items[key]
 	c.RUnlock()
 	return v, found
+}
+
+// Delete removes a key from ReadHeavyCache.
+func (c *ReadHeavyCache[K, V]) Delete(key K) {
+	c.Lock()
+	delete(c.items, key)
+	c.Unlock()
 }
 
 // Clear removes all items from ReadHeavyCache
@@ -130,6 +144,13 @@ func (c *WriteHeavyCacheExpired[K, V]) Get(key K) (V, bool) {
 	return v.value, true
 }
 
+// Delete removes a key from WriteHeavyCacheExpired.
+func (c *WriteHeavyCacheExpired[K, V]) Delete(key K) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.items, key)
+}
+
 // Set method for ReadHeavyCacheExpired with a specified expiration duration
 func (c *ReadHeavyCacheExpired[K, V]) Set(key K, value V, duration time.Duration) {
 	val := expiredValue[V]{
@@ -151,6 +172,13 @@ func (c *ReadHeavyCacheExpired[K, V]) Get(key K) (V, bool) {
 		return zero, false
 	}
 	return v.value, true
+}
+
+// Delete removes a key from ReadHeavyCacheExpired.
+func (c *ReadHeavyCacheExpired[K, V]) Delete(key K) {
+	c.Lock() // Write lock is required for deletion.
+	defer c.Unlock()
+	delete(c.items, key)
 }
 
 // WriteHeavyCacheInteger is a cache optimized for write-heavy operations for integer-like types.
@@ -216,6 +244,13 @@ func (c *WriteHeavyCacheInteger[K, V]) Incr(key K, value V) {
 	c.Unlock()
 }
 
+// Delete removes a key from WriteHeavyCacheInteger.
+func (c *WriteHeavyCacheInteger[K, V]) Delete(key K) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.items, key)
+}
+
 // Clear removes all items from WriteHeavyCacheInteger.
 func (c *WriteHeavyCacheInteger[K, V]) Clear() {
 	c.Lock()
@@ -248,6 +283,13 @@ func (c *ReadHeavyCacheInteger[K, V]) Incr(key K, value V) {
 		c.items[key] = value
 	}
 	c.Unlock()
+}
+
+// Delete removes a key from ReadHeavyCacheInteger.
+func (c *ReadHeavyCacheInteger[K, V]) Delete(key K) {
+	c.Lock() // Write lock is required for deletion.
+	defer c.Unlock()
+	delete(c.items, key)
 }
 
 // Clear removes all items from ReadHeavyCacheExpired.

--- a/cache_test.go
+++ b/cache_test.go
@@ -20,6 +20,17 @@ func TestWriteHeavyCache_SetAndGet(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCache_Delete(t *testing.T) {
+	cache := cache.NewWriteHeavyCache[string, int]()
+	cache.Set("key1", 100)
+
+	// Delete the key and check if it's removed
+	cache.Delete("key1")
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be deleted")
+	}
+}
+
 func TestReadHeavyCache_SetAndGet(t *testing.T) {
 	cache := cache.NewReadHeavyCache[string, int]()
 	cache.Set("key1", 200)
@@ -43,6 +54,17 @@ func TestWriteHeavyCache_Clear(t *testing.T) {
 	}
 	if _, found := cache.Get("key2"); found {
 		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
+func TestReadHeavyCache_Delete(t *testing.T) {
+	cache := cache.NewReadHeavyCache[string, int]()
+	cache.Set("key1", 200)
+
+	// Delete the key and check if it's removed
+	cache.Delete("key1")
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be deleted")
 	}
 }
 
@@ -72,6 +94,17 @@ func TestWriteHeavyCacheInteger_SetAndGet(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCacheExpired_Delete(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheExpired[string, string]()
+	cache.Set("key1", "value1", 10*time.Second)
+
+	// Delete the key and check if it's removed
+	cache.Delete("key1")
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be deleted")
+	}
+}
+
 func TestReadHeavyCacheInteger_SetAndGet(t *testing.T) {
 	cache := cache.NewReadHeavyCacheInteger[int, int]()
 	cache.Set(1, 400)
@@ -80,6 +113,17 @@ func TestReadHeavyCacheInteger_SetAndGet(t *testing.T) {
 		t.Errorf("Expected key 1 to be found")
 	} else if value != 400 {
 		t.Errorf("Expected value 400 for key 1, but got %d", value)
+	}
+}
+
+func TestReadHeavyCacheExpired_Delete(t *testing.T) {
+	cache := cache.NewReadHeavyCacheExpired[string, string]()
+	cache.Set("key1", "value1", 10*time.Second)
+
+	// Delete the key and check if it's removed
+	cache.Delete("key1")
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be deleted")
 	}
 }
 
@@ -102,6 +146,17 @@ func TestWriteHeavyCacheInteger_Incr(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCacheInteger_Delete(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheInteger[int, int]()
+	cache.Set(1, 300)
+
+	// Delete the key and check if it's removed
+	cache.Delete(1)
+	if _, found := cache.Get(1); found {
+		t.Errorf("Expected key 1 to be deleted")
+	}
+}
+
 func TestReadHeavyCacheInteger_Incr(t *testing.T) {
 	cache := cache.NewReadHeavyCacheInteger[int, int]()
 	cache.Incr(1, 20) // Key doesn't exist, should set to 20
@@ -118,6 +173,17 @@ func TestReadHeavyCacheInteger_Incr(t *testing.T) {
 		t.Errorf("Expected key 1 to be found")
 	} else if value != 30 {
 		t.Errorf("Expected value 30 for key 1, but got %d", value)
+	}
+}
+
+func TestReadHeavyCacheInteger_Delete(t *testing.T) {
+	cache := cache.NewReadHeavyCacheInteger[int, int]()
+	cache.Set(1, 400)
+
+	// Delete the key and check if it's removed
+	cache.Delete(1)
+	if _, found := cache.Get(1); found {
+		t.Errorf("Expected key 1 to be deleted")
 	}
 }
 


### PR DESCRIPTION
This pull request adds a `Delete` method to various cache types and includes corresponding test cases to ensure the functionality works as expected. The most important changes include the addition of the `Delete` method to different cache types and the implementation of test cases for these methods.

### Additions to cache types:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R37-R43): Added `Delete` method to `WriteHeavyCache`, `ReadHeavyCache`, `WriteHeavyCacheExpired`, `ReadHeavyCacheExpired`, `WriteHeavyCacheInteger`, and `ReadHeavyCacheInteger` to allow removal of keys from the caches. [[1]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R37-R43) [[2]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R66-R72) [[3]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R147-R153) [[4]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R177-R183) [[5]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R247-R253) [[6]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R288-R294)

### Test cases:

* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R23-R33): Added test cases `TestWriteHeavyCache_Delete`, `TestReadHeavyCache_Delete`, `TestWriteHeavyCacheExpired_Delete`, `TestReadHeavyCacheExpired_Delete`, `TestWriteHeavyCacheInteger_Delete`, and `TestReadHeavyCacheInteger_Delete` to verify that the `Delete` method correctly removes keys from the caches. [[1]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R23-R33) [[2]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R60-R70) [[3]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R97-R107) [[4]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R119-R129) [[5]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R149-R159) [[6]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R179-R189)

close #13