### PR TITLE
Add Clear method to WriteHeavyCacheExpired and ReadHeavyCacheExpired

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -151,6 +151,13 @@ func (c *WriteHeavyCacheExpired[K, V]) Delete(key K) {
 	delete(c.items, key)
 }
 
+// Clear removes all items from WriteHeavyCache
+func (c *WriteHeavyCacheExpired[K, V]) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.items = make(map[K]expiredValue[V])
+}
+
 // Set method for ReadHeavyCacheExpired with a specified expiration duration
 func (c *ReadHeavyCacheExpired[K, V]) Set(key K, value V, duration time.Duration) {
 	val := expiredValue[V]{
@@ -179,6 +186,13 @@ func (c *ReadHeavyCacheExpired[K, V]) Delete(key K) {
 	c.Lock() // Write lock is required for deletion.
 	defer c.Unlock()
 	delete(c.items, key)
+}
+
+// Clear removes all items from WriteHeavyCache
+func (c *ReadHeavyCacheExpired[K, V]) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.items = make(map[K]expiredValue[V])
 }
 
 // WriteHeavyCacheInteger is a cache optimized for write-heavy operations for integer-like types.

--- a/cache_test.go
+++ b/cache_test.go
@@ -83,6 +83,36 @@ func TestReadHeavyCache_Clear(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCacheExpired_Clear(t *testing.T) {
+	cache := cache.NewWriteHeavyCacheExpired[string, int]()
+	cache.Set("key1", 100, 10*time.Second)
+	cache.Set("key2", 200, 10*time.Second)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
+func TestReadHeavyCacheExpired_Clear(t *testing.T) {
+	cache := cache.NewReadHeavyCacheExpired[string, int]()
+	cache.Set("key1", 100, 10*time.Second)
+	cache.Set("key2", 200, 10*time.Second)
+
+	cache.Clear()
+
+	if _, found := cache.Get("key1"); found {
+		t.Errorf("Expected key1 to be cleared")
+	}
+	if _, found := cache.Get("key2"); found {
+		t.Errorf("Expected key2 to be cleared")
+	}
+}
+
 func TestWriteHeavyCacheInteger_SetAndGet(t *testing.T) {
 	cache := cache.NewWriteHeavyCacheInteger[int, int]()
 	cache.Set(1, 300)


### PR DESCRIPTION
This pull request introduces a new `Clear` method to both the `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` cache types and adds corresponding tests to ensure the functionality works as expected. The most important changes include the addition of the `Clear` method and the implementation of tests for this new method.

### New Methods:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R154-R160): Added `Clear` method to `WriteHeavyCacheExpired` to remove all items from the cache.
* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R191-R197): Added `Clear` method to `ReadHeavyCacheExpired` to remove all items from the cache.

### Tests:

* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R86-R115): Added `TestWriteHeavyCacheExpired_Clear` to verify that the `Clear` method correctly removes all items from the `WriteHeavyCacheExpired` cache.
* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R86-R115): Added `TestReadHeavyCacheExpired_Clear` to verify that the `Clear` method correctly removes all items from the `ReadHeavyCacheExpired` cache.