### PR TITLE
update cache module version to v0.2.0 in go.mod and go.sum files

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -3,7 +3,7 @@ module github.com/catatsuy/cache/benchmark
 go 1.23.3
 
 require (
-	github.com/catatsuy/cache v0.1.3 // indirect
-	github.com/catatsuy/sync v0.0.1 // indirect
-	golang.org/x/sync v0.9.0 // indirect
+	github.com/catatsuy/cache v0.2.0
+	github.com/catatsuy/sync v0.0.1
+	golang.org/x/sync v0.9.0
 )

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,5 +1,5 @@
-github.com/catatsuy/cache v0.1.3 h1:GzoMCZXguJnQ39/j/ISuVVAyWLX4n/Jp8MxYkDJhf3Y=
-github.com/catatsuy/cache v0.1.3/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
+github.com/catatsuy/cache v0.2.0 h1:AGQLRAYzU/HSHaxQB1Ih2mFrWT2Kwd8veaUukaFT14s=
+github.com/catatsuy/cache v0.2.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
 github.com/catatsuy/sync v0.0.1 h1:xIRkpBV3+q2oV6HahIEU3dOVjx3dfZDQfRMN4wG98Xs=
 github.com/catatsuy/sync v0.0.1/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
 golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=


### PR DESCRIPTION
This pull request includes an update to the `benchmark/go.mod` file to upgrade the version of the `github.com/catatsuy/cache` dependency.

Dependency updates:

* [`benchmark/go.mod`](diffhunk://#diff-f601bca2d8fd90d228b7d89d1287dd2e1154960b5df371952f355c2ee185a0daL6-R8): Upgraded `github.com/catatsuy/cache` from version `v0.1.3` to `v0.2.0`.