### PR TITLE
Add RollingCache with Append, Rotate, GetItems, and Size methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This library provides efficient caching solutions for various usage patterns, su
 - **ReadHeavyCache**: Optimized for frequent read operations.
 - **Expiration Support**: Built-in expiration for cache entries in `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired`.
 - **Integer-Specific Caches**: Specialized caches (`WriteHeavyCacheInteger` and `ReadHeavyCacheInteger`) with increment operations.
+- **RollingCache**: A dynamically growing slice-based cache with efficient `Append` and `Rotate` operations, suitable for maintaining ordered sequences of elements.
 - **Faster Singleflight**: A custom implementation that is up to **2x faster** than the standard Singleflight. See detailed results in the [benchmark](/benchmark) directory.
 - **LockManager**: Simplified locking for managing concurrency in your applications.
 
@@ -227,6 +228,43 @@ func main() {
 	time.Sleep(1 * time.Second)
 	lm.Unlock(1)
 	fmt.Println("Main goroutine released lock")
+}
+```
+
+### RollingCache
+
+The `RollingCache` provides a simple, dynamically growing cache for ordered elements. It supports appending new items and rotating the cache, which resets its contents while returning the previous state.
+
+#### Example
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/catatsuy/cache"
+)
+
+func main() {
+	// Create a RollingCache with an initial capacity of 10
+	c := cache.NewRollingCache[int](10)
+	c.Append(1)
+	c.Append(2)
+	c.Append(3)
+
+	// Get the current items
+	fmt.Println("Current items:", c.GetItems()) // Output: Current items: [1 2 3]
+
+	// Check the size of the cache
+	fmt.Println("Current size:", c.Size()) // Output: Current size: 3
+
+	// Rotate the cache and get the rotated items
+	rotated := c.Rotate()
+	fmt.Println("Rotated items:", rotated) // Output: Rotated items: [1 2 3]
+
+	// The cache should now be empty
+	fmt.Println("Items after rotation:", c.GetItems()) // Output: Items after rotation: []
 }
 ```
 

--- a/example_test.go
+++ b/example_test.go
@@ -154,6 +154,78 @@ func ExampleReadHeavyCacheExpired() {
 	// Item has expired
 }
 
+// Example for RollingCache Append and GetItems
+func ExampleRollingCache() {
+	c := cache.NewRollingCache[int](10)
+
+	// Append values
+	c.Append(1)
+	c.Append(2)
+	c.Append(3)
+
+	// Get the items
+	items := c.GetItems()
+	fmt.Println("Items:", items)
+	// Output: Items: [1 2 3]
+}
+
+// Example for RollingCache with dynamic growth
+func ExampleRollingCache_dynamicGrowth() {
+	c := cache.NewRollingCache[int](10)
+
+	// Append more values than the initial length
+	c.Append(1)
+	c.Append(2)
+	c.Append(3)
+	c.Append(4) // This grows the slice beyond the initial length
+
+	items := c.GetItems()
+	fmt.Println("Items after appending more:", items)
+	// Output: Items after appending more: [1 2 3 4]
+}
+
+// Example for RollingCache Rotate
+func ExampleRollingCache_Rotate() {
+	c := cache.NewRollingCache[int](10)
+
+	// Append values
+	c.Append(1)
+	c.Append(2)
+	c.Append(3)
+
+	// Rotate the cache
+	rotated := c.Rotate()
+	fmt.Println("Rotated items:", rotated)
+
+	// Cache should now be empty
+	fmt.Println("Items after rotation:", c.GetItems())
+	// Output:
+	// Rotated items: [1 2 3]
+	// Items after rotation: []
+}
+
+// Example for RollingCache Size
+func ExampleRollingCache_Size() {
+	c := cache.NewRollingCache[int](10)
+
+	// Initially empty
+	fmt.Println("Size initially:", c.Size())
+
+	// Append values
+	c.Append(1)
+	c.Append(2)
+	fmt.Println("Size after appending:", c.Size())
+
+	// Append another value
+	c.Append(3)
+	fmt.Println("Size after appending more:", c.Size())
+
+	// Output:
+	// Size initially: 0
+	// Size after appending: 2
+	// Size after appending more: 3
+}
+
 // Example for LockManager with GetAndLock
 func ExampleLockManager_GetAndLock() {
 	var lm = cache.NewLockManager[int]()


### PR DESCRIPTION
This pull request introduces a new `RollingCache` type to the `cache.go` file, along with corresponding tests in `cache_test.go`. The `RollingCache` is a thread-safe cache that supports appending and rotating operations, and maintains an initial length for resetting the slice.

### New `RollingCache` Implementation:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R424-R478): Added a new `RollingCache` type that uses a slice for storing elements, with methods for appending values, rotating the cache, retrieving items, and getting the size of the cache.

### Tests for `RollingCache`:

* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R520-R600): Added tests for the `AppendAndGetItems`, `Rotate`, and `Size` methods of the `RollingCache` to ensure correct functionality.