### PR TITLE
Reorganize LockManager documentation and adjust RollingCache example size

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,40 +202,9 @@ func main() {
 }
 ```
 
-### LockManager
-
-The `LockManager` is designed for managing locks associated with unique keys.
-
-```go
-package main
-
-import (
-	"fmt"
-	"time"
-
-	"github.com/catatsuy/cache"
-)
-
-func main() {
-	lm := cache.NewLockManager[int]()
-
-	lm.Lock(1)
-	go func() {
-		defer lm.GetAndLock(1).Unlock()
-		fmt.Println("Goroutine locked and released")
-	}()
-
-	time.Sleep(1 * time.Second)
-	lm.Unlock(1)
-	fmt.Println("Main goroutine released lock")
-}
-```
-
 ### RollingCache
 
 The `RollingCache` provides a simple, dynamically growing cache for ordered elements. It supports appending new items and rotating the cache, which resets its contents while returning the previous state.
-
-#### Example
 
 ```go
 package main
@@ -265,6 +234,35 @@ func main() {
 
 	// The cache should now be empty
 	fmt.Println("Items after rotation:", c.GetItems()) // Output: Items after rotation: []
+}
+```
+
+### LockManager
+
+The `LockManager` is designed for managing locks associated with unique keys.
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/catatsuy/cache"
+)
+
+func main() {
+	lm := cache.NewLockManager[int]()
+
+	lm.Lock(1)
+	go func() {
+		defer lm.GetAndLock(1).Unlock()
+		fmt.Println("Goroutine locked and released")
+	}()
+
+	time.Sleep(1 * time.Second)
+	lm.Unlock(1)
+	fmt.Println("Main goroutine released lock")
 }
 ```
 

--- a/example_test.go
+++ b/example_test.go
@@ -171,7 +171,7 @@ func ExampleRollingCache() {
 
 // Example for RollingCache with dynamic growth
 func ExampleRollingCache_dynamicGrowth() {
-	c := cache.NewRollingCache[int](10)
+	c := cache.NewRollingCache[int](3)
 
 	// Append more values than the initial length
 	c.Append(1)


### PR DESCRIPTION
This pull request includes changes to the `README.md` and `example_test.go` files to improve documentation and examples. The most important changes include reordering sections in the `README.md` file and modifying the `ExampleRollingCache_dynamicGrowth` function in the `example_test.go` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-L239): Moved the `LockManager` section to a different position within the file to improve the logical flow of the documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-L239) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240-R268)

Example updates:

* [`example_test.go`](diffhunk://#diff-c2ade2f386c41794d5ebc57ee49b57a5fca8082e03255e5bff13977cbc061287L174-R174): Changed the initial length parameter of the `RollingCache` in the `ExampleRollingCache_dynamicGrowth` function from 10 to 3 to better demonstrate dynamic growth.