### PR TITLE
modify benchmark tests

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 
 RUN apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*
 

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -17,12 +17,12 @@ func BenchmarkStandardSingleflight(b *testing.B) {
 	keys := generateKeys(10)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			key := keys[i%10]
-			sg.Do(key, func() (interface{}, error) {
+			sg.Do(key, func() (any, error) {
 				return i, nil
 			})
 		}(i)
@@ -37,16 +37,17 @@ func BenchmarkStandardSingleflightCast(b *testing.B) {
 	keys := generateKeys(10)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			key := keys[i%10]
-			ii, _, _ := sg.Do(key, func() (interface{}, error) {
+			ii, _, _ := sg.Do(key, func() (any, error) {
 				return i, nil
 			})
 			if _, ok := ii.(int); !ok {
-				b.Fatalf("unexpected type: %T", ii)
+				b.Errorf("unexpected type: %T", ii)
+				return
 			}
 		}(i)
 	}
@@ -60,7 +61,7 @@ func BenchmarkGenericsSingleflight(b *testing.B) {
 	keys := generateKeys(10)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -80,7 +81,7 @@ func BenchmarkCustomSingleflight(b *testing.B) {
 	keys := generateKeys(10)
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -95,7 +96,7 @@ func BenchmarkCustomSingleflight(b *testing.B) {
 
 func generateKeys(n int) []string {
 	keys := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		keys[i] = "key-" + strconv.Itoa(i)
 	}
 	return keys


### PR DESCRIPTION
This pull request includes updates to the `benchmark` directory, focusing on improving the Docker setup and refining the benchmark tests. The most important changes include updating the Go version in the Dockerfile, modifying the loop syntax in benchmark functions, and replacing the `interface{}` type with `any`.

Improvements to Docker setup:

* [`benchmark/Dockerfile`](diffhunk://#diff-5b448215f5a2b2c7bd6e5c23a7a52bfd24454fe3b3c4045fefbac8313195f201L1-R1): Updated the Go version from 1.23 to 1.24.

Refinements to benchmark tests:

* [`benchmark/benchmark_test.go`](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL20-R25): Changed the loop syntax from `for i := 0; i < b.N; i++` to `for i := range b.N` in multiple benchmark functions for better readability and performance. [[1]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL20-R25) [[2]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL40-R50) [[3]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL63-R64) [[4]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL83-R84) [[5]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL98-R99)
* [`benchmark/benchmark_test.go`](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL20-R25): Replaced the `interface{}` type with `any` to use the new Go 1.18 type alias for better code clarity. [[1]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL20-R25) [[2]](diffhunk://#diff-e23064a1e36f6abc739e3c22d5e57e0a4950a70dedc4ee70a0b4bf3e2e821f2fL40-R50)