### PR TITLE
Fix: Use `range` for loop variable in tests/benchmarks

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -267,7 +267,7 @@ func TestWriteHeavyCache_ParallelWrite(t *testing.T) {
 	wg.Wait()
 
 	// Verify if all values are set correctly
-	for p := 0; p < numProcs; p++ {
+	for p := range numProcs {
 		for i := range 1000 {
 			if value, found := cache.Get(p*1000 + i); !found || value != i {
 				t.Errorf("Expected value %d for key %d, but got %d (found: %v)", i, p*1000+i, value, found)
@@ -296,7 +296,7 @@ func TestReadHeavyCache_ParallelWrite(t *testing.T) {
 	wg.Wait()
 
 	// Verify if all values are set correctly
-	for p := 0; p < numProcs; p++ {
+	for p := range numProcs {
 		for i := range 1000 {
 			if value, found := cache.Get(p*1000 + i); !found || value != i {
 				t.Errorf("Expected value %d for key %d, but got %d (found: %v)", i, p*1000+i, value, found)
@@ -684,7 +684,7 @@ func BenchmarkWriteHeavyCache_ParallelWrite(b *testing.B) {
 			wg.Add(1)
 			go func(procID int) {
 				defer wg.Done()
-				for j := 0; j < 1000; j++ {
+				for j := range 1000 {
 					cache.Set(procID*1000+j, j)
 				}
 			}(p)
@@ -727,11 +727,11 @@ func BenchmarkWriteHeavyCacheInteger_ParallelWrite(b *testing.B) {
 
 	for range b.N {
 		// Parallel writes using GOMAXPROCS goroutines
-		for p := 0; p < numProcs; p++ {
+		for p := range numProcs {
 			wg.Add(1)
 			go func(procID int) {
 				defer wg.Done()
-				for j := 0; j < 1000; j++ {
+				for j := range 1000 {
 					cache.Set(procID*1000+j, j)
 				}
 			}(p)
@@ -751,11 +751,11 @@ func BenchmarkReadHeavyCacheInteger_ParallelWrite(b *testing.B) {
 
 	for range b.N {
 		// Parallel writes using GOMAXPROCS goroutines
-		for p := 0; p < numProcs; p++ {
+		for p := range numProcs {
 			wg.Add(1)
 			go func(procID int) {
 				defer wg.Done()
-				for j := 0; j < 1000; j++ {
+				for j := range 1000 {
 					cache.Set(procID*1000+j, j)
 				}
 			}(p)
@@ -780,11 +780,11 @@ func BenchmarkWriteHeavyCacheInteger_ParallelIncr(b *testing.B) {
 
 	for range b.N {
 		// Parallel increments using GOMAXPROCS goroutines
-		for p := 0; p < numProcs; p++ {
+		for p := range numProcs {
 			wg.Add(1)
 			go func(procID int) {
 				defer wg.Done()
-				for j := 0; j < 1000; j++ {
+				for j := range 1000 {
 					cache.Incr(procID*1000+j, 1)
 				}
 			}(p)
@@ -809,11 +809,11 @@ func BenchmarkReadHeavyCacheInteger_ParallelIncr(b *testing.B) {
 
 	for range b.N {
 		// Parallel increments using GOMAXPROCS goroutines
-		for p := 0; p < numProcs; p++ {
+		for p := range numProcs {
 			wg.Add(1)
 			go func(procID int) {
 				defer wg.Done()
-				for j := 0; j < 1000; j++ {
+				for j := range 1000 {
 					cache.Incr(procID*1000+j, 1)
 				}
 			}(p)

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -58,7 +58,7 @@ func TestDoDupSuppress(t *testing.T) {
 	const n = 100
 
 	wg1.Add(1)
-	for i := 0; i < n; i++ {
+	for range n {
 		wg1.Add(1)
 		wg2.Add(1)
 		go func() {
@@ -109,7 +109,7 @@ func TestDoMultipleErrors(t *testing.T) {
 
 	const n = 10
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for range n {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
This pull request includes changes to the `cache_test.go` and `singleflight_test.go` files to improve the readability and maintainability of the test and benchmark code. The main change involves replacing traditional `for` loops with range-based `for` loops.

Improvements to test and benchmark code:

* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L270-R270): Replaced traditional `for` loops with range-based `for` loops in multiple functions to improve readability (`TestWriteHeavyCache_ParallelWrite`, `TestReadHeavyCache_ParallelWrite`, `BenchmarkWriteHeavyCache_ParallelWrite`, `BenchmarkWriteHeavyCacheInteger_ParallelWrite`, `BenchmarkReadHeavyCacheInteger_ParallelWrite`, `BenchmarkWriteHeavyCacheInteger_ParallelIncr`, `BenchmarkReadHeavyCacheInteger_ParallelIncr`). [[1]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L270-R270) [[2]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L299-R299) [[3]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L687-R687) [[4]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L730-R734) [[5]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L754-R758) [[6]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L783-R787) [[7]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L812-R816)
* [`singleflight_test.go`](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL61-R61): Replaced traditional `for` loops with range-based `for` loops in `TestDoDupSuppress` and `TestDoMultipleErrors` to enhance code consistency and readability. [[1]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL61-R61) [[2]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL112-R112)