### PR TITLE
 singleflight: add shared bool return value to indicate duplicate calls

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -317,7 +317,7 @@ func ExampleLockManager() {
 func ExampleSingleflightGroup() {
 	sf := cache.NewSingleflightGroup[string]()
 
-	v, err := sf.Do("example_key", func() (string, error) {
+	v, err, _ := sf.Do("example_key", func() (string, error) {
 		return "result", nil
 	})
 	if err != nil {

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDo(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
-	v, err := sf.Do("key", func() (string, error) {
+	v, err, _ := sf.Do("key", func() (string, error) {
 		return "bar", nil
 	})
 	if got, want := v, "bar"; got != want {
@@ -26,7 +26,7 @@ func TestDo(t *testing.T) {
 func TestDoErr(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
 	someErr := errors.New("Some error")
-	v, err := sf.Do("key", func() (string, error) {
+	v, err, _ := sf.Do("key", func() (string, error) {
 		return "", someErr
 	})
 	if err != someErr {
@@ -64,7 +64,7 @@ func TestDoDupSuppress(t *testing.T) {
 		go func() {
 			defer wg2.Done()
 			wg1.Done()
-			v, err := sf.Do("key", fn)
+			v, err, _ := sf.Do("key", fn)
 			if err != nil {
 				t.Errorf("Do error: %v", err)
 				return
@@ -87,7 +87,7 @@ func TestDoDupSuppress(t *testing.T) {
 func TestDoTimeout(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
 	start := time.Now()
-	v, err := sf.Do("key", func() (string, error) {
+	v, err, _ := sf.Do("key", func() (string, error) {
 		time.Sleep(100 * time.Millisecond)
 		return "bar", nil
 	})
@@ -113,7 +113,7 @@ func TestDoMultipleErrors(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			v, err := sf.Do("key", func() (string, error) {
+			v, err, _ := sf.Do("key", func() (string, error) {
 				atomic.AddInt32(&calls, 1)
 				time.Sleep(10 * time.Millisecond)
 				return "", someErr


### PR DESCRIPTION
This pull request modifies the `SingleflightGroup` implementation to include a shared result flag in its `Do` method, indicating whether the result was reused for multiple callers. Corresponding updates have been made to the tests and examples to reflect this change.

### Feature enhancement: Shared result flag in `Do` method
* [`singleflight.go`](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L50-R51): Updated the `Do` method to include a third return value (`shared`), which indicates whether the result was shared among multiple callers. Adjusted the logic to set this flag appropriately. [[1]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L50-R51) [[2]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65R71-R78)

### Documentation updates
* [`singleflight.go`](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L15-L17): Removed outdated comments regarding the absence of a shared result indicator, as this feature has now been implemented.

### Test updates
* [`singleflight_test.go`](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL15-R15): Modified all test cases (`TestDo`, `TestDoErr`, `TestDoDupSuppress`, `TestDoTimeout`, `TestDoMultipleErrors`) to accommodate the additional `shared` return value in the `Do` method. [[1]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL15-R15) [[2]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL29-R29) [[3]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL67-R67) [[4]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL90-R90) [[5]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL116-R116)

### Example updates
* [`example_test.go`](diffhunk://#diff-c2ade2f386c41794d5ebc57ee49b57a5fca8082e03255e5bff13977cbc061287L320-R320): Updated the `ExampleSingleflightGroup` function to include the new `shared` return value from the `Do` method.