### PR TITLE
Update Go version matrix from 1.23.x to 1.24.x in CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23.x"]
+        go: ["1.24.x"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
This pull request updates the Go version used in the GitHub Actions workflow for the repository.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL9-R9): Updated the matrix configuration to use Go version `1.24.x` instead of `1.23.x`.