### PR TITLE
ignore third return value from SingleflightGroup's Do calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ func main() {
 	}
 
 	// Use SingleflightGroup to ensure only one call for the same key at a time
-	value, err := sf.Do("key", func() (string, error) {
+	value, err, _ := sf.Do("key", func() (string, error) {
 		return loadData("key")
 	})
 
@@ -333,7 +333,7 @@ func Get(key int) int {
 	}
 
 	// Use SingleflightGroup to prevent duplicate HeavyGet calls for the same key
-	v, err := sf.Do(fmt.Sprintf("cacheGet_%d", key), func() (int, error) {
+	v, err, _ := sf.Do(fmt.Sprintf("cacheGet_%d", key), func() (int, error) {
 		// Load the data and store it in the cache
 		value := HeavyGet(key)
 		c.Set(key, value)


### PR DESCRIPTION
This pull request makes small changes to the `README.md` file to update the usage of the `SingleflightGroup` pattern. Specifically, it modifies the `Do` method calls to include an additional return value (`bool`), which is ignored in both instances. These changes align the examples with the updated method signature of `SingleflightGroup.Do`.