### PR TITLE
update benchmark dependencies to newer module versions

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -3,7 +3,7 @@ module github.com/catatsuy/cache/benchmark
 go 1.23.3
 
 require (
-	github.com/catatsuy/cache v0.2.0
-	github.com/catatsuy/sync v0.0.1
-	golang.org/x/sync v0.9.0
+	github.com/catatsuy/cache v0.4.0
+	github.com/catatsuy/sync v0.0.2
+	golang.org/x/sync v0.14.0
 )

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,6 +1,6 @@
-github.com/catatsuy/cache v0.2.0 h1:AGQLRAYzU/HSHaxQB1Ih2mFrWT2Kwd8veaUukaFT14s=
-github.com/catatsuy/cache v0.2.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
-github.com/catatsuy/sync v0.0.1 h1:xIRkpBV3+q2oV6HahIEU3dOVjx3dfZDQfRMN4wG98Xs=
-github.com/catatsuy/sync v0.0.1/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
-golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=
-golang.org/x/sync v0.9.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+github.com/catatsuy/cache v0.4.0 h1:Ud6umIJ7QAcQ0Q6n0MAEfbCWml+sFKwnfyk7j7U1CrU=
+github.com/catatsuy/cache v0.4.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
+github.com/catatsuy/sync v0.0.2 h1:Exx80knesqc4hq49WW4G17k7PxFFtfSiSPMqLTsyRWY=
+github.com/catatsuy/sync v0.0.2/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=


### PR DESCRIPTION
This pull request updates dependencies in the `benchmark/go.mod` file to use newer versions of libraries.

Dependency updates:

* [`github.com/catatsuy/cache`](diffhunk://#diff-f601bca2d8fd90d228b7d89d1287dd2e1154960b5df371952f355c2ee185a0daL6-R8): Updated from `v0.2.0` to `v0.4.0`.
* [`github.com/catatsuy/sync`](diffhunk://#diff-f601bca2d8fd90d228b7d89d1287dd2e1154960b5df371952f355c2ee185a0daL6-R8): Updated from `v0.0.1` to `v0.0.2`.
* [`golang.org/x/sync`](diffhunk://#diff-f601bca2d8fd90d228b7d89d1287dd2e1154960b5df371952f355c2ee185a0daL6-R8): Updated from `v0.9.0` to `v0.14.0`.