### PR TITLE
remove shared flag

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -317,7 +317,7 @@ func ExampleLockManager() {
 func ExampleSingleflightGroup() {
 	sf := cache.NewSingleflightGroup[string]()
 
-	v, err, _ := sf.Do("example_key", func() (string, error) {
+	v, err := sf.Do("example_key", func() (string, error) {
 		return "result", nil
 	})
 	if err != nil {

--- a/singleflight.go
+++ b/singleflight.go
@@ -12,6 +12,9 @@ import (
 //   - Panic and runtime.Goexit handling: This implementation does not handle cases
 //     where the function panics or terminates abnormally. In the official implementation,
 //     errors from panic and Goexit are handled to prevent blocked goroutines.
+//   - Shared result indicator: The official singleflight implementation includes a boolean
+//     return value to indicate if the result was shared among multiple callers. This
+//     implementation does not include this feature.
 //   - Immediate synchronous cleanup: In this implementation, the completed result is
 //     removed from the map asynchronously. In the official implementation, cleanup
 //     is handled synchronously within the doCall function to ensure immediate memory release.
@@ -44,11 +47,15 @@ func NewSingleflightGroup[V any]() *SingleflightGroup[V] {
 //
 // Unlike the official singleflight, this function does not provide:
 //   - Panic and Goexit handling
-func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (v V, err error, shared bool) {
+//   - Shared result flag to indicate if the result was reused for multiple callers
+func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (V, error) {
 	// Lock to check if a call is already in progress for the given key
 	sf.mu.Lock()
-	c, ok := sf.m[key]
-	if !ok {
+	var (
+		c  *call[V]
+		ok bool
+	)
+	if c, ok = sf.m[key]; !ok {
 		// If no call exists for the key, create a new one
 		c = &call[V]{}
 		sf.m[key] = c
@@ -68,12 +75,8 @@ func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (v V, err e
 			delete(sf.m, key)
 			sf.mu.Unlock()
 		}()
-
-		c.mu.Unlock()
-
-		return c.value, c.err, false
 	}
 	c.mu.Unlock()
 
-	return c.value, c.err, true
+	return c.value, c.err
 }

--- a/singleflight.go
+++ b/singleflight.go
@@ -51,11 +51,8 @@ func NewSingleflightGroup[V any]() *SingleflightGroup[V] {
 func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (V, error) {
 	// Lock to check if a call is already in progress for the given key
 	sf.mu.Lock()
-	var (
-		c  *call[V]
-		ok bool
-	)
-	if c, ok = sf.m[key]; !ok {
+	c, ok := sf.m[key]
+	if !ok {
 		// If no call exists for the key, create a new one
 		c = &call[V]{}
 		sf.m[key] = c

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDo(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
-	v, err, _ := sf.Do("key", func() (string, error) {
+	v, err := sf.Do("key", func() (string, error) {
 		return "bar", nil
 	})
 	if got, want := v, "bar"; got != want {
@@ -26,7 +26,7 @@ func TestDo(t *testing.T) {
 func TestDoErr(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
 	someErr := errors.New("Some error")
-	v, err, _ := sf.Do("key", func() (string, error) {
+	v, err := sf.Do("key", func() (string, error) {
 		return "", someErr
 	})
 	if err != someErr {
@@ -64,7 +64,7 @@ func TestDoDupSuppress(t *testing.T) {
 		go func() {
 			defer wg2.Done()
 			wg1.Done()
-			v, err, _ := sf.Do("key", fn)
+			v, err := sf.Do("key", fn)
 			if err != nil {
 				t.Errorf("Do error: %v", err)
 				return
@@ -87,7 +87,7 @@ func TestDoDupSuppress(t *testing.T) {
 func TestDoTimeout(t *testing.T) {
 	sf := cache.NewSingleflightGroup[string]()
 	start := time.Now()
-	v, err, _ := sf.Do("key", func() (string, error) {
+	v, err := sf.Do("key", func() (string, error) {
 		time.Sleep(100 * time.Millisecond)
 		return "bar", nil
 	})
@@ -113,7 +113,7 @@ func TestDoMultipleErrors(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			v, err, _ := sf.Do("key", func() (string, error) {
+			v, err := sf.Do("key", func() (string, error) {
 				atomic.AddInt32(&calls, 1)
 				time.Sleep(10 * time.Millisecond)
 				return "", someErr


### PR DESCRIPTION
This pull request refactors the `SingleflightGroup` implementation and its tests to simplify the return values of the `Do` method. The method no longer returns a "shared" boolean flag, aligning the code with the documented limitations and making the API easier to use. All related test cases and example usages have been updated accordingly.

**SingleflightGroup API simplification:**

* Changed the signature of `SingleflightGroup.Do` to remove the `shared` boolean return value, so it now returns only the value and error. The documentation was updated to reflect this limitation. (`singleflight.go`) [[1]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L47-R51) [[2]](diffhunk://#diff-9db9223851999d7b863d6a9e2aab89bb299aa9ae02126a8be72c9531b5541a65L71-R78)
* Added a note in the documentation that the shared result indicator is not supported in this implementation. (`singleflight.go`)

**Test and example updates:**

* Updated all usages of `SingleflightGroup.Do` in tests to remove the unused `shared` return value, simplifying the test code. (`singleflight_test.go`) [[1]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL15-R15) [[2]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL29-R29) [[3]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL67-R67) [[4]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL90-R90) [[5]](diffhunk://#diff-4b4484b82f80c6d9ade94a5859be83a85086d4d01390cad66f4dfc78f616396cL116-R116)
* Updated the example code to match the new `Do` method signature. (`example_test.go`)