### PR TITLE
test workflow: add Go 1.25.x matrix and update checkout action to v5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.24.x"]
+        go: ["1.24.x", "1.25.x"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -15,7 +15,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: test
         run: |


### PR DESCRIPTION
This pull request updates the Go workflow configuration to improve CI coverage and keep dependencies up to date.

CI workflow improvements:

* Updated the Go version matrix to test against both `1.24.x` and the new `1.25.x` release, ensuring compatibility with the latest Go version.
* Upgraded the `actions/checkout` GitHub Action from version `v4` to `v5` for improved performance and security.