### PR TITLE
update benchmark to use Go 1.25 and cache v0.5.0

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 RUN apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*
 

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -1,9 +1,9 @@
 module github.com/catatsuy/cache/benchmark
 
-go 1.23.3
+go 1.25
 
 require (
-	github.com/catatsuy/cache v0.4.0
+	github.com/catatsuy/cache v0.5.0
 	github.com/catatsuy/sync v0.0.2
 	golang.org/x/sync v0.14.0
 )

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,5 +1,5 @@
-github.com/catatsuy/cache v0.4.0 h1:Ud6umIJ7QAcQ0Q6n0MAEfbCWml+sFKwnfyk7j7U1CrU=
-github.com/catatsuy/cache v0.4.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
+github.com/catatsuy/cache v0.5.0 h1:vhCg3DwCtoQ/dQSS5z+jK1bCsK/5zAtcokjniDxr6gQ=
+github.com/catatsuy/cache v0.5.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
 github.com/catatsuy/sync v0.0.2 h1:Exx80knesqc4hq49WW4G17k7PxFFtfSiSPMqLTsyRWY=
 github.com/catatsuy/sync v0.0.2/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=


### PR DESCRIPTION
This pull request updates the Go version and the cache library used in the benchmark environment to ensure compatibility with the latest features and improvements.

Environment updates:

* Updated the base image in `benchmark/Dockerfile` from `golang:1.24` to `golang:1.25` to use the latest Go version.
* Updated the Go version in `benchmark/go.mod` from `1.23.3` to `1.25` for consistency with the Dockerfile and to leverage new language features.

Dependency updates:

* Bumped `github.com/catatsuy/cache` dependency from version `v0.4.0` to `v0.5.0` in `benchmark/go.mod` to include the latest improvements and bug fixes.