### PR TITLE
Improve benchmark README with detailed impl notes and new results on EC2

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,32 +4,68 @@ This repository benchmarks different implementations of the singleflight pattern
 
 ## Implementations
 
-- **StandardSingleflight**: Uses the `golang.org/x/sync/singleflight` package.
-- **StandardSingleflightCast**: Similar to `StandardSingleflight` but includes type assertions.
-- **GenericsSingleflight**: A patched version of `golang.org/x/sync/singleflight` to support Go generics, implemented in the https://github.com/catatsuy/sync repository.
-- **CustomSingleflight**: A fully custom implementation optimized for speed and memory usage.
+- **StandardSingleflight**
+  Baseline using `golang.org/x/sync/singleflight`. `interface{}` API, supports panic/Goexit propagation, a shared-result flag, and **synchronous cleanup** after `fn` finishes.
+
+- **StandardSingleflightCast**
+  Same as StandardSingleflight; the benchmark additionally does a type assertion (e.g., `v.(int)`) to measure that overhead. Not a different library—just a benchmark variant.
+
+- **GenericsSingleflight**
+  Minimal patch of the standard implementation to add generics (`Group[T]`), hosted at `github.com/catatsuy/sync/singleflight`. Semantics match the standard version (panic/Goexit, shared flag, **synchronous delete**), with slightly fewer allocations.
+
+- **CustomSingleflight**
+  Fully custom, generics-based implementation in `github.com/catatsuy/cache` focused on latency and zero allocations. Key differences: **return-first with asynchronous map delete**, per-call mutex to guarantee single execution, **no shared flag**, and **no panic/Goexit handling** (non-goal). Intended for idempotent, finite operations (e.g., cache fills).
+
+> **Contract for CustomSingleflight:** `fn` does not panic, is idempotent, and completes in finite time. If you need panic propagation or the shared flag, use the standard implementation.
 
 ## Benchmark Results
+
+EC2 c7g.xlarge (Graviton3, 4 vCPU) / Debian 13 / Go 1.25.0
 
 ```
 goos: linux
 goarch: arm64
 pkg: github.com/catatsuy/cache/benchmark
-BenchmarkStandardSingleflight-8          1000000              1081 ns/op             168 B/op          2 allocs/op
-BenchmarkStandardSingleflightCast-8      1000000              1115 ns/op             126 B/op          2 allocs/op
-BenchmarkGenericsSingleflight-8          1000000              1145 ns/op             102 B/op          2 allocs/op
-BenchmarkCustomSingleflight-8            1974880               573.0 ns/op           110 B/op          2 allocs/op
+BenchmarkSingleflight/std/keys=1                18591908               196.6 ns/op            88 B/op          1 allocs/op
+BenchmarkSingleflight/std/keys=1-2              16908397               213.3 ns/op            87 B/op          1 allocs/op
+BenchmarkSingleflight/std/keys=1-4              10718676               331.7 ns/op            82 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=1           18222015               197.3 ns/op            88 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=1-2         16597257               212.4 ns/op            87 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=1-4         10827585               329.7 ns/op            82 B/op          1 allocs/op
+BenchmarkSingleflight/generics/keys=1           17918259               202.7 ns/op            80 B/op          1 allocs/op
+BenchmarkSingleflight/generics/keys=1-2         16597784               217.6 ns/op            79 B/op          0 allocs/op
+BenchmarkSingleflight/generics/keys=1-4         11186880               308.9 ns/op            75 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=1             79731640                42.67 ns/op            0 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=1-2           24880732               127.3 ns/op             0 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=1-4           25826616               152.3 ns/op             0 B/op          0 allocs/op
+BenchmarkSingleflight/std/keys=10               18039288               199.9 ns/op            88 B/op          1 allocs/op
+BenchmarkSingleflight/std/keys=10-2             17164132               206.7 ns/op            87 B/op          1 allocs/op
+BenchmarkSingleflight/std/keys=10-4             12818521               282.4 ns/op            86 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=10          18266598               199.8 ns/op            88 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=10-2        17554419               204.8 ns/op            87 B/op          1 allocs/op
+BenchmarkSingleflight/std-cast/keys=10-4        12830840               281.9 ns/op            86 B/op          1 allocs/op
+BenchmarkSingleflight/generics/keys=10          17554911               200.8 ns/op            80 B/op          1 allocs/op
+BenchmarkSingleflight/generics/keys=10-2        16990652               211.6 ns/op            79 B/op          0 allocs/op
+BenchmarkSingleflight/generics/keys=10-4        12554142               286.3 ns/op            78 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=10            69217628                49.34 ns/op            0 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=10-2          32092108               113.9 ns/op             0 B/op          0 allocs/op
+BenchmarkSingleflight/custom/keys=10-4          21601365               164.6 ns/op             7 B/op          0 allocs/op
 PASS
-ok      github.com/catatsuy/cache/benchmark     5.526s
 ```
 
-## Observations
+## Observations (EC2 c7g.xlarge, linux/arm64)
 
-- `CustomSingleflight` is:
-  - **1.89x faster** than `StandardSingleflight`.
-  - **1.95x faster** than `StandardSingleflightCast`.
-  - **2.00x faster** than `GenericsSingleflight`.
-- `CustomSingleflight` also uses the least memory per operation, with only 110 B/op.
+- Setup: `go test -bench=. -benchmem -benchtime=3s -cpu=1,2,4` (RunParallel), `keys=1,10`, trivial `fn` (`return i, nil`).
+- **CustomSingleflight is consistently fastest.**
+  - `keys=1` (worst contention): **42.67 ns/op** vs std **196.6** (@P=1 → ~**4.6×**), **152.3** vs **331.7** (@P=4 → ~**2.2×**).
+  - `keys=10` (moderate contention): **49.34** vs **199.9** (@P=1 → ~**4.0×**), **164.6** vs **282.4** (@P=4 → ~**1.7×**).
+- **Allocations / memory**
+  - CustomSingleflight: **0 allocs/op (≈0 B/op)**.
+  - GenericsSingleflight: **0–1 allocs/op (~75–80 B/op)**.
+  - Standard / StandardSingleflightCast: **1 alloc/op (~86–88 B/op)**.
+- Standard vs StandardSingleflightCast are essentially identical → type assertion cost is negligible.
+
+> Absolute ns/op varies by machine, but the ordering and relative gaps are consistent in our tests.
 
 ## Setup and Run
 


### PR DESCRIPTION
This pull request updates the `benchmark/README.md` to provide a much more detailed and accurate explanation of the different singleflight implementations and their benchmark results. The documentation now clarifies the design and contract of each implementation, presents expanded benchmark data, and offers clearer observations about performance and memory usage.

### Documentation improvements

* Expanded and clarified descriptions for each implementation (`StandardSingleflight`, `StandardSingleflightCast`, `GenericsSingleflight`, `CustomSingleflight`), including their API, semantics, and intended use cases. The contract and limitations of `CustomSingleflight` are now explicitly stated.

### Benchmark results and analysis

* Updated benchmark results to show a broader range of scenarios (varying key counts and CPU counts), with more granular data for each implementation.
* Added a detailed analysis section highlighting performance and allocation differences, and clarified that absolute timings may vary but relative performance is consistent.

### Usability and clarity

* Improved formatting and explanations to make the results and recommendations easier to interpret, including explicit notes on setup and the negligible cost of type assertions.