### PR TITLE
Add GetWithExpireStatus for SWR and update docs with usage example

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -341,6 +341,46 @@ func TestReadHeavyCacheExpired_SetAndGet(t *testing.T) {
 	}
 }
 
+func TestWriteHeavyCacheExpired_GetWithExpireStatus(t *testing.T) {
+	c := cache.NewWriteHeavyCacheExpired[int, string]()
+
+	c.Set(1, "value", 100*time.Millisecond)
+
+	if v, found, expired := c.GetWithExpireStatus(1); !found || expired || v != "value" {
+		t.Errorf("expected found=true expired=false value, got found=%v expired=%v value=%v", found, expired, v)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	if v, found, expired := c.GetWithExpireStatus(1); !found || !expired || v != "value" {
+		t.Errorf("expected found=true expired=true value, got found=%v expired=%v value=%v", found, expired, v)
+	}
+
+	if _, found := c.Get(1); found {
+		t.Errorf("expected Get to report not found for expired item")
+	}
+}
+
+func TestReadHeavyCacheExpired_GetWithExpireStatus(t *testing.T) {
+	c := cache.NewReadHeavyCacheExpired[int, string]()
+
+	c.Set(1, "value", 100*time.Millisecond)
+
+	if v, found, expired := c.GetWithExpireStatus(1); !found || expired || v != "value" {
+		t.Errorf("expected found=true expired=false value, got found=%v expired=%v value=%v", found, expired, v)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	if v, found, expired := c.GetWithExpireStatus(1); !found || !expired || v != "value" {
+		t.Errorf("expected found=true expired=true value, got found=%v expired=%v value=%v", found, expired, v)
+	}
+
+	if _, found := c.Get(1); found {
+		t.Errorf("expected Get to report not found for expired item")
+	}
+}
+
 func TestWriteHeavyCache_GetItems(t *testing.T) {
 	cache := cache.NewWriteHeavyCache[string, int]()
 	cache.Set("key1", 100)


### PR DESCRIPTION
This pull request adds support for stale-while-revalidate (SWR) caching patterns to both `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired`. The key change is the introduction of the `GetWithExpireStatus` method, which allows clients to retrieve cached values even if they are expired, enabling immediate serving of stale data while a background refresh is triggered. The documentation and tests have been updated to reflect and validate this new behavior.

**Stale-While-Revalidate Support:**

* Added `GetWithExpireStatus` method to both `WriteHeavyCacheExpired` and `ReadHeavyCacheExpired` in `cache.go`, enabling retrieval of a value along with its expiration status for SWR use cases. [[1]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R201-R215) [[2]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R253-R267)

**Documentation Updates:**

* Updated `README.md` to document the new SWR pattern, including a usage example and explanation of `GetWithExpireStatus`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R108) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158-R201)

**Testing:**

* Added unit tests in `cache_test.go` to verify the correct behavior of `GetWithExpireStatus` for both cache types, including handling of expired and non-expired entries.