### PR TITLE
fix race by checking call before deleting from map in goroutine

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -69,7 +69,10 @@ func (sf *SingleflightGroup[V]) Do(key string, fn func() (V, error)) (V, error) 
 		// Schedule the deletion of the completed call asynchronously
 		go func() {
 			sf.mu.Lock()
-			delete(sf.m, key)
+			// Only delete if the call in the map is the same as the completed one
+			if sf.m[key] == c {
+				delete(sf.m, key)
+			}
 			sf.mu.Unlock()
 		}()
 	}


### PR DESCRIPTION
This pull request makes a targeted fix to the `SingleflightGroup` implementation to address potential race conditions when deleting completed calls from the internal map.

* Concurrency safety improvement:
  * In `singleflight.go`, updated the asynchronous cleanup logic in `SingleflightGroup.Do` to only delete the call from the map if the reference matches the completed call, preventing possible data races or accidental deletion of new calls for the same key.