### PR TITLE
Update benchmark dependencies

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -1,9 +1,9 @@
 module github.com/catatsuy/cache/benchmark
 
-go 1.25
+go 1.25.1
 
 require (
-	github.com/catatsuy/cache v0.5.0
+	github.com/catatsuy/cache v0.5.2
 	github.com/catatsuy/sync v0.0.2
-	golang.org/x/sync v0.14.0
+	golang.org/x/sync v0.17.0
 )

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,6 +1,6 @@
-github.com/catatsuy/cache v0.5.0 h1:vhCg3DwCtoQ/dQSS5z+jK1bCsK/5zAtcokjniDxr6gQ=
-github.com/catatsuy/cache v0.5.0/go.mod h1:Ppaed4sPVG6q25/vLaj1B2ZG6VRh1XbGI+Gx1v5//2U=
+github.com/catatsuy/cache v0.5.2 h1:X06E+BiU023sxeYO7cnFIUptZJc9N+o+6BwJEMAVptw=
+github.com/catatsuy/cache v0.5.2/go.mod h1:Vp5gE9+Ys6MJqHLvAr0lNfv8b5myKss9XefS7BM+Cqo=
 github.com/catatsuy/sync v0.0.2 h1:Exx80knesqc4hq49WW4G17k7PxFFtfSiSPMqLTsyRWY=
 github.com/catatsuy/sync v0.0.2/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
-golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
-golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=


### PR DESCRIPTION
This pull request updates dependencies and the Go version in the `benchmark/go.mod` file to ensure compatibility and benefit from recent improvements.

Dependency updates:

* Updated the `github.com/catatsuy/cache` dependency from version `v0.5.0` to `v0.5.2`.
* Updated the `golang.org/x/sync` dependency from version `v0.14.0` to `v0.17.0`.

Go version update:

* Changed the Go version from `1.25` to `1.25.1` for the benchmark module.