### PR TITLE
add benchmark module with replace directive

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,15 @@
 name: Go
-on: [push]
+on:
+  push:
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - benchmark/*.go
+      - benchmark/go.mod
+      - benchmark/go.sum
+      - Makefile
+      - .github/workflows/go.yml
 jobs:
   test:
     name: Build
@@ -24,5 +34,4 @@ jobs:
 
       - name: benchmark
         run: |
-          cd benchmark
-          go test -bench=. -benchmem -benchtime=3s -cpu=1,2,4
+          go test -C benchmark -modfile=go.mod -bench=. -benchmem -benchtime=3s -cpu=1,2,4

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 
 .PHONY: bench
 bench:
-	go test -bench=. -benchmem
+	go test -C benchmark -modfile=go.mod -bench=. -benchmem
 
 .PHONY: vet
 vet:

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ The `benchmark/` module compares several singleflight variants in Go. Singleflig
 
 ### Benchmark Results
 
+Benchmarks use a dedicated module in `benchmark/go.mod` so they can evolve dependencies independently; run them with `go test -C benchmark -modfile=go.mod` to pick up the local sources.
+
 Environment: EC2 c7g.xlarge (Graviton3, 4 vCPU) / Debian 13 / Go 1.25.1
 
 ```
@@ -300,7 +302,7 @@ PASS
 ![keys=1](benchmark/images/ns_op%20-%20keys=1.png)
 ![keys=10](benchmark/images/ns_op%20-%20keys=10.png)
 
-- Setup: `go test -bench=. -benchmem -benchtime=3s -cpu=1,2,4` (RunParallel), `keys=1,10`, trivial `fn` (`return i, nil`).
+- Setup: `go test -C benchmark -modfile=go.mod -bench=. -benchmem -benchtime=3s -cpu=1,2,4` (RunParallel), `keys=1,10`, trivial `fn` (`return i, nil`).
 - **CustomSingleflight is consistently fastest.**
   - `keys=1` (worst contention): **42.49 ns/op** vs std **195.1** (@P=1 → ~**4.6×**), **151.2** vs **337.7** (@P=4 → ~**2.2×**).
   - `keys=10` (moderate contention): **49.51** vs **197.5** (@P=1 → ~**4.0×**), **199.8** vs **302.3** (@P=4 → ~**1.5×**).
@@ -322,11 +324,10 @@ docker build -t benchmark-runner .
 docker run --rm benchmark-runner
 ```
 
-Or, run the Go benchmarks directly:
+Or, run the Go benchmarks directly from the repository root:
 
 ```bash
-cd benchmark
-go test -bench=. -benchmem -benchtime=3s -cpu=1,2,4
+go test -C benchmark -modfile=go.mod -bench=. -benchmem -benchtime=3s -cpu=1,2,4
 ```
 
 ## Documentation

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,7 +58,7 @@ PASS
 
 ![keys=10](./images/ns_op%20-%20keys=10.png)
 
-- Setup: `go test -bench=. -benchmem -benchtime=3s -cpu=1,2,4` (RunParallel), `keys=1,10`, trivial `fn` (`return i, nil`).
+- Setup: `go test -C benchmark -modfile=go.mod -bench=. -benchmem -benchtime=3s -cpu=1,2,4` (RunParallel), `keys=1,10`, trivial `fn` (`return i, nil`).
 - **CustomSingleflight is consistently fastest.**
   - `keys=1` (worst contention): **42.49 ns/op** vs std **195.1** (@P=1 → ~**4.6×**), **151.2** vs **337.7** (@P=4 → ~**2.2×**).
   - `keys=10` (moderate contention): **49.51** vs **197.5** (@P=1 → ~**4.0×**), **199.8** vs **302.3** (@P=4 → ~**1.5×**).

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -3,7 +3,9 @@ module github.com/catatsuy/cache/benchmark
 go 1.25.1
 
 require (
-	github.com/catatsuy/cache v0.5.2
+	github.com/catatsuy/cache v0.0.0
 	github.com/catatsuy/sync v0.0.2
 	golang.org/x/sync v0.17.0
 )
+
+replace github.com/catatsuy/cache => ../

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,5 +1,3 @@
-github.com/catatsuy/cache v0.5.2 h1:X06E+BiU023sxeYO7cnFIUptZJc9N+o+6BwJEMAVptw=
-github.com/catatsuy/cache v0.5.2/go.mod h1:Vp5gE9+Ys6MJqHLvAr0lNfv8b5myKss9XefS7BM+Cqo=
 github.com/catatsuy/sync v0.0.2 h1:Exx80knesqc4hq49WW4G17k7PxFFtfSiSPMqLTsyRWY=
 github.com/catatsuy/sync v0.0.2/go.mod h1:y380VTE1YaSjcQW0jav0Yas3RPefPbxVxRMAVO526w0=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=


### PR DESCRIPTION
This pull request updates the workflow and documentation for running Go benchmarks, ensuring that benchmarks use the dedicated `benchmark` module and its dependencies. The changes improve consistency across the CI workflow, Makefile, and documentation, making it easier to run benchmarks from the repository root and ensuring local sources are used.

**Benchmark workflow and tooling updates:**

* The GitHub Actions workflow `.github/workflows/go.yml` now only runs on changes to Go source files, the Makefile, or relevant workflow files, and the benchmark step uses the `-C benchmark -modfile=go.mod` flags to run tests from the correct module and pick up local sources. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL2-R12) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL27-R37)
* The `Makefile` benchmark target is updated to run benchmarks from the `benchmark` directory using the same flags, ensuring consistency with CI and local runs.

**Documentation and usage improvements:**

* The main `README.md` and `benchmark/README.md` are updated to instruct users to run benchmarks from the repository root using `go test -C benchmark -modfile=go.mod ...`, reflecting the new workflow and making the process clearer. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R266-R267) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L303-R305) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L325-R330) [[4]](diffhunk://#diff-7fe6b01752be42136da1c4bfcc273aa482497b35192a5af3fc46027766c59ae1L61-R61)

**Module dependency management:**

* The `benchmark/go.mod` file now uses a `replace` directive to point `github.com/catatsuy/cache` to the local source (`../`), ensuring benchmarks always use the latest local code instead of a published version.